### PR TITLE
Use pyproj 2 syntax for transformations

### DIFF
--- a/atmcorr/tiling.py
+++ b/atmcorr/tiling.py
@@ -81,10 +81,9 @@ def _transform_corners(corners, src_crs, dst_crs):
     ndarray, ndarray
         projected coordinates
     """
-    src_proj = pyproj.Proj(src_crs)
-    dst_proj = pyproj.Proj(dst_crs)
+    transformer = pyproj.Transformer.from_crs(src_crs, dst_crs, always_xy=True)
     xs, ys = corners
-    xout, yout = pyproj.transform(src_proj, dst_proj, xs, ys)
+    xout, yout = transformer.transform(xs, ys)
     return xout, yout
 
 
@@ -113,7 +112,7 @@ def _corners_to_extents(xs, ys):
     return extent_rec
 
 
-def get_projected_extents(transform, height, width, src_crs, dst_crs={'init': 'epsg:4326'}):
+def get_projected_extents(transform, height, width, src_crs, dst_crs='epsg:4326'):
     """Get extents of pixels in WGS84 or other projection
 
     Parameters
@@ -138,7 +137,7 @@ def get_projected_extents(transform, height, width, src_crs, dst_crs={'init': 'e
     return _corners_to_extents(xproj, yproj)
 
 
-def bounds_to_projected_extents(left, bottom, right, top, src_crs, dst_crs={'init': 'epsg:4326'}):
+def bounds_to_projected_extents(left, bottom, right, top, src_crs, dst_crs='epsg:4326'):
     """Get extents record array from bounds
 
     Parameters
@@ -153,15 +152,14 @@ def bounds_to_projected_extents(left, bottom, right, top, src_crs, dst_crs={'ini
     np.recarray shape (1, 1)
         with names xmin, xmax, ymin, ymax
     """
-    src_proj = pyproj.Proj(src_crs)
-    dst_proj = pyproj.Proj(dst_crs)
+    transformer = pyproj.Transformer.from_crs(src_crs, dst_crs, always_xy=True)
     xs = np.array([left, left, right, right])
     ys = np.array([bottom, top, top, bottom])
-    xproj, yproj = pyproj.transform(src_proj, dst_proj, xs, ys)
+    xproj, yproj = transformer.transform(xs, ys)
     return _corners_to_extents(xproj, yproj)[np.newaxis, np.newaxis]
 
 
-def get_projected_image_extent(transform, height, width, src_crs, dst_crs={'init': 'epsg:4326'}):
+def get_projected_image_extent(transform, height, width, src_crs, dst_crs='epsg:4326'):
     """Get extents of a whole image in WGS84 or other projection
 
     Parameters

--- a/tests/processing/test_processing.py
+++ b/tests/processing/test_processing.py
@@ -19,7 +19,7 @@ def _get_inputs():
     mtdFile = MTDFILES['WV02.imd']
     profile = dict(
             width=nx, height=ny,
-            crs=rasterio.crs.CRS({'init': 'epsg:32640'}),
+            crs=rasterio.crs.CRS('epsg:32640'),
             transform=affine.Affine(
                 2.0, 0.0, 364466.0808031342,
                 0.0, -2.0, 2836767.9090107735),

--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -20,14 +20,14 @@ def test_get_projected_extents():
         transform=affine.Affine(10, 0, 36000, 0, -10, 18000),
         height=100,
         width=200,
-        src_crs={'init': 'epsg:4032'})
+        src_crs='epsg:4032')
     assert extent_rec.shape == (100, 200)
     assert 'xmin' in extent_rec.dtype.names
 
 
 def test_bounds_to_projected_extents():
     bounds = (364466.0808031342, 2829605.9090107735, 365034.0808031342, 2836767.9090107735)
-    src_crs = {'init': 'epsg:32640'}
+    src_crs = 'epsg:32640'
     extent_rec = tiling.bounds_to_projected_extents(*bounds, src_crs=src_crs)
     assert extent_rec.shape == (1, 1)
     assert 'xmin' in extent_rec.dtype.names
@@ -39,7 +39,7 @@ def test_recarr_take_dict():
         transform=affine.Affine(10, 0, 36000, 0, -10, 18000),
         height=100,
         width=200,
-        src_crs={'init': 'epsg:4032'})
+        src_crs='epsg:4032')
     d = tiling.recarr_take_dict(a, 0, 0)
     assert type(d) == dict
     assert np.issubdtype(d['xmin'], np.floating)


### PR DESCRIPTION
Use pyproj 2 style transformations, as described here: https://pyproj4.github.io/pyproj/stable/gotchas.html#upgrading-to-pyproj-2-from-pyproj-1

This has the added benefit of eliminating errors when testing bathymetry, see: https://github.com/DHI-GRAS/bathymetry/runs/4224543901?check_suite_focus=true (which is a branch on bathymetry which uses _this_ branch to test against -- hence, do _not_ merge that branch in bathymetry)